### PR TITLE
build: fix undeclared dep on sandbox-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -10,7 +10,8 @@
 
 (define test-omit-paths '("test_main.rkt"
                           "test_make_functional_setter.rkt"))
+
 (define build-deps '("at-exp-lib"
                      "racket-doc"
-
+                     "sandbox-lib"
                      "scribble-lib"))


### PR DESCRIPTION
`raco setup --tidy --check-pkg-deps --unused-pkg-deps struct-plus-plus` would complain that it was missing otherwise.